### PR TITLE
fix: add redhat-release to runtime image for check-payload compatibility

### DIFF
--- a/.tekton/mutli-arch-build-pipeline.yaml
+++ b/.tekton/mutli-arch-build-pipeline.yaml
@@ -161,6 +161,85 @@ spec:
       operator: in
       values:
       - "true"
+  - name: fips-check
+    matrix:
+      params:
+      - name: image-platform
+        value:
+        - $(params.build-platforms)
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: blocking
+      value: "true"
+    runAfter:
+    - build-image-index
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    taskSpec:
+      params:
+      - name: image-platform
+        type: string
+      - name: image-url
+        type: string
+      - name: image-digest
+        type: string
+      - name: blocking
+        type: string
+        default: "true"
+      steps:
+      - name: prepare-image-list
+        image: quay.io/konflux-ci/appstudio-utils:latest
+        script: |
+          #!/bin/bash
+          set -e
+          IMAGE_WITHOUT_TAG="${IMAGE_URL%%:*}"
+          PLATFORM="${IMAGE_PLATFORM//\//-}"
+          PLATFORM_DIGEST=$(skopeo inspect --raw docker://${IMAGE_WITHOUT_TAG}@${IMAGE_DIGEST} | jq -r \
+            --arg platform "${IMAGE_PLATFORM}" \
+            '.manifests[] | select(.platform.os + "/" + .platform.architecture == $platform) | .digest')
+          if [ -z "${PLATFORM_DIGEST}" ]; then
+            PLATFORM_DIGEST="${IMAGE_DIGEST}"
+          fi
+          printf '%s' "${IMAGE_WITHOUT_TAG}@${PLATFORM_DIGEST}" > /tekton/home/unique_related_images.txt
+        env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+        - name: IMAGE_PLATFORM
+          value: $(params.image-platform)
+      - name: run-fips-check
+        ref:
+          resolver: git
+          params:
+          - name: url
+            value: https://github.com/konflux-ci/konflux-operator-tasks.git
+          - name: revision
+            value: dee7049a3aae9294b121faf76af66506cd76f5a0
+          - name: pathInRepo
+            value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+      - name: evaluate-result
+        image: quay.io/rhoai-konflux/alpine:latest
+        env:
+        - name: TEST_OUTPUT
+          value: $(steps.run-fips-check.results.TEST_OUTPUT)
+        - name: BLOCKING
+          value: $(params.blocking)
+        script: |
+          echo "${TEST_OUTPUT}"
+          if echo "${TEST_OUTPUT}" | grep -qE '"result":"(FAILURE|ERROR)"'; then
+            if [ "${BLOCKING}" = "true" ]; then
+              echo "FIPS check failed and blocking is enabled"
+              exit 1
+            fi
+            echo "FIPS check failed but blocking is not enabled, continuing"
+          fi
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL

--- a/Containerfile.wasm-shim
+++ b/Containerfile.wasm-shim
@@ -32,6 +32,8 @@ USER 1001
 # Run Stage
 # ------------------------------------------------------------------------------
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
+USER 0
+RUN microdnf install -y redhat-release && microdnf clean all
 USER 1001
 LABEL version="0.14.1" \
       com.redhat.component="wasm-shim-container" \

--- a/Containerfile.wasm-shim
+++ b/Containerfile.wasm-shim
@@ -32,8 +32,6 @@ USER 1001
 # Run Stage
 # ------------------------------------------------------------------------------
 FROM registry.redhat.io/ubi9/ubi-minimal:latest
-USER 0
-RUN microdnf install -y redhat-release && microdnf clean all
 USER 1001
 LABEL version="0.14.1" \
       com.redhat.component="wasm-shim-container" \


### PR DESCRIPTION
## Summary

Add a FIPS compliance check step to the wasm-shim multi-arch build pipeline.

## Changes

Adds a new \`fips-check\` Tekton task to \`.tekton/mutli-arch-build-pipeline.yaml\` that runs after \`build-image-index\`. The task:

1. Resolves the per-platform image digest from the multi-arch index
2. Runs the \`fips-operator-check-step-action\` from \`konflux-ci/konflux-operator-tasks\` against each platform image
3. Evaluates the result and fails the pipeline if the check reports \`FAILURE\` or \`ERROR\` (when \`blocking: true\`)

The check runs in matrix mode across all build platforms and is skipped when \`skip-checks\` is set to \`true\`.

## Test plan

- [ ] Konflux PR build passes including the new fips-check task
- [ ] FIPS check runs for each platform (x86_64, arm64, s390x, ppc64le)