### PR TITLE
Fix CPE label to cpe:/a:redhat:connectivity_link:1.4::el9

### DIFF
--- a/Containerfile.wasm-shim
+++ b/Containerfile.wasm-shim
@@ -36,7 +36,7 @@ USER 1001
 LABEL version="0.14.2" \
       com.redhat.component="wasm-shim-container" \
       name="rhcl-1/wasm-shim-rhel9" \
-      cpe="cpe:/a:redhat:connectivity_link:1::el9" \
+      cpe="cpe:/a:redhat:connectivity_link:1.4::el9" \
       summary="A Proxy-Wasm module written in Rust, acting as a shim between Envoy and Limitador." \
       description="A Proxy-Wasm module written in Rust, acting as a shim between Envoy and Limitador." \
       distribution-scope="public" \


### PR DESCRIPTION
Updates the `cpe` label in all Containerfiles from `cpe:/a:redhat:connectivity_link:1::el9` to `cpe:/a:redhat:connectivity_link:1.4::el9` to match the RHCL 1.4 product version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)