### PR TITLE
Fix CPE label to connectivity_link:1.5 in Containerfiles

### DIFF
--- a/Containerfile.wasm-shim
+++ b/Containerfile.wasm-shim
@@ -36,7 +36,7 @@ USER 1001
 LABEL version="0.14.1" \
       com.redhat.component="wasm-shim-container" \
       name="rhcl-1/wasm-shim-rhel9" \
-      cpe="cpe:/a:redhat:connectivity_link:1::el9" \
+      cpe="cpe:/a:redhat:connectivity_link:1.5::el9" \
       summary="A Proxy-Wasm module written in Rust, acting as a shim between Envoy and Limitador." \
       description="A Proxy-Wasm module written in Rust, acting as a shim between Envoy and Limitador." \
       distribution-scope="public" \


### PR DESCRIPTION
Updates the `cpe` label in all Containerfiles from `cpe:/a:redhat:connectivity_link:1::el9` to `cpe:/a:redhat:connectivity_link:1.5::el9` to match the expected CPE for the RHCL 1.5 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)